### PR TITLE
(fix) Solana Pay now works with Solflare and Backpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "yvrbepsi-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@solana-program/token": "^0.3.1",
+        "@solana/addresses": "^2.0.0-rc.1",
         "@tanstack/react-query": "^4.29.19",
         "@types/node": "20.4.1",
         "@types/react": "18.2.14",
@@ -2350,6 +2352,28 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/@solana/web3.js": {
+      "version": "1.95.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.3.tgz",
+      "integrity": "sha512-O6rPUN0w2fkNqx/Z3QJMB9L225Ex10PRDH8bTaIUPZXMPV0QP8ZpPvjQnXK+upUczlRgzHzd6SjKIha1p+I6og==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
       }
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/bn.js": {
@@ -6437,6 +6461,56 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@solana-program/token": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.3.1.tgz",
+      "integrity": "sha512-EPPYjNnw7M7jiXSog3CVYdrFYiji5n3VxbgK9T9y6zpNSlvHvaSrWPdZU+Q0pLCi73EQyvk7oF3jsa/0Lb4ckg==",
+      "peerDependencies": {
+        "@solana/web3.js": "2.0.0-rc.1"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0-rc.1.tgz",
+      "integrity": "sha512-au6grz6iIgepKIbN2HUHKatFhg7mvIvdjFMDYpuEx+AGwK7vHnN5PsJqSCGQydthC2nVQwSZC9IgA5MF5wUHdw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0-rc.1.tgz",
+      "integrity": "sha512-g31KrLZdECjAKceShlGoYxnWDmEVklpjPs8xOtnj/HWupEk+Mds4vtmTACTAeJkWZW/3x+z0aexMtO86MKA47g==",
+      "dependencies": {
+        "@solana/assertions": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-dvxYCUB7ftZa5lWcsyMYLsGm204H6yVN8Q3ngluMG0rhTtScMBRklVg7Vs39ISwJOkJWJPGToaZ7DjNJ83bm1Q==",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
@@ -6448,33 +6522,515 @@
         "node": ">=5.10"
       }
     },
-    "node_modules/@solana/web3.js": {
-      "version": "1.95.3",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.3.tgz",
-      "integrity": "sha512-O6rPUN0w2fkNqx/Z3QJMB9L225Ex10PRDH8bTaIUPZXMPV0QP8ZpPvjQnXK+upUczlRgzHzd6SjKIha1p+I6og==",
-      "license": "MIT",
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "@noble/curves": "^1.4.2",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.1",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^2.0.2"
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
       }
     },
-    "node_modules/@solana/web3.js/node_modules/bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    "node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0-rc.1.tgz",
+      "integrity": "sha512-TN8JY+Sbh5NNq4TqdWil8hXKx2d84bTHvY6jfBXNjM29S0fwpUpVRHUzOkuK1mjjWFNkMpfgJfozC0TjdUbkvA==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0-rc.1.tgz",
+      "integrity": "sha512-BmedS5o8HTlU8/NA22I6urJqat9QYIw0oH6rKdMMBisDwX7MtgJhe38W8iLP7QCcxoJeS4526qaD8uD62+Pheg==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-zkfL4WBHPbkMrYsuGZc/sekPa/oALIVvVGUw/gwAervMeLZ34cWCUE6WC2uUUh+bq3OFq0/FSFhAg2YbHHDyUw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ls3B0KOvfdiBH3/fnEjHhicfXsLLb4zApJlSX4X8NZ+2TmTJ2Jqa+MakgAzrsxL1FJkTJ1RDboR9xx2CHQtKzw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/assertions": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-wF49DychwSz3sVmTF51R6DTHBGMP7Uhe7EdmCNu+Ef9EgKBJZFfrViOD6M8Q0b3WH//TV63HNlX/2QmHtJjQHg==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0-rc.1.tgz",
+      "integrity": "sha512-iIaC52Ka+omGabGn2LHOSgEm9N2gI7Iyik6LE3DDxZ4MuYmGcJ4E315XuE/UVXWnc9qOfOjgtSaaOYhde0vyrQ==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0-rc.1.tgz",
+      "integrity": "sha512-upqR/Ae5syzQDZkffTdU/09k1Vx073Gt4xkkpcWaTBmW0obVhrlvJvH2k5jrOQ13BZd2NVg1MWMEOBcy3+nJjQ==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/fast-stable-stringify": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/rpc-api": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-transport-http": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0-rc.1.tgz",
+      "integrity": "sha512-pg/w+0pgj3msBCC/hkZa9/qZHRdqh7MLsHMJInXnenO+Rzj6IyE47Ig6rt6GuI4OxYy+1d714jcPXVMA8p2YWw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-parsed-types": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-5/AYNiZvR9do56VJgmTscRwnd9myt6x9uG7b0S3V+K5e0xzA9yJF68SzI4TQSNmLfWXCaVC90xGCWWkM19lLIQ==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0-rc.1.tgz",
+      "integrity": "sha512-E81IoNzLbp24T633klEqlRujd2i/rd8xVkJGt04DL/LGS4/cCWJEhkmOnfljxWafCPUundRXlPtNG3ZmHzEYqA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/rpc-spec-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-Z0gOrzasTYU+kNNnDDG2snZxBoBPMN8oFc0EE9HiDKN9JEsc+asexzKeq+Nea7JVqVFcN5V3bjqrpD86V5EOiQ==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-gHrVNWEbMi8uDO8BzpJkuDiHMcfD4SrfLRohROnHx0SfSlEGxvIkBjPnwOYIoS7IkWk95e19s7hJoBNn2TX4kw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/fast-stable-stringify": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/promises": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-api": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-transport-websocket": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0-rc.1.tgz",
+      "integrity": "sha512-HmuJmB+RnpYzpiwDWncYFey0lrdFt8KbFvH0JvxEB7NX6V9NgGQIwRY1bfoaeSwX6t93p4nBWr2ckJWLNjXzCw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0-rc.1.tgz",
+      "integrity": "sha512-eXRVlMr9zw4JlBoJgVhFRxFs3Iaowhtt35ZIMD+OoTqgKniL62iGiZ3hXsuMDToMvQCBd0UfI+ZVdF2gLQdg9A==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/rpc-subscriptions-transport-websocket": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-transport-websocket/-/rpc-subscriptions-transport-websocket-2.0.0-rc.1.tgz",
+      "integrity": "sha512-NxheQmG6Ku9gjF3TyGbM8Nxx6fOU3m89LdfH9SQNu6yME6VXKWuT1LaY24T707yDOoKZJsOWabRrQtNfJ+3HZA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5",
+        "ws": "^8.14.0"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-YM25X4Eeh39UR2AoSrCFn74W99bQk0/DLqyPgZpNBRbszzEifGHqu83NNFwBuPMVc9q7ilf5s6r6pqhWP+5JJw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0-rc.1.tgz",
+      "integrity": "sha512-Byvn2LnaCgTnEyr78wcgh8SrVHo+L6/l1kXQW05cNAjjbS8d8z4meBUBrXDWHmCsWy7RdnrTcBixPPtE+pUebw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "undici-types": "^6.19.5"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-EcGx9VXqA0+uYEdaa1lKTaGBVxLyNL8nkecE4GkqQ+ntRyYlNBPecd4b8siQGSleUQa+Tk/VSPUawSkHqNTLug==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-dv3oKSF+AIaHKpnSkmzEf+jXVcA3nl015+Mp/WQZYzQJS01dlrmnd4N5DOSn2CaPRJ0TLujHkupxkOFXbe149A==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0-rc.1.tgz",
+      "integrity": "sha512-nLiuisgbRw7FkJrxPJOBzf0ro7ZCk0gWgMyLQexe9oPoTzdZnWbHI4ldYDmtfdy2dkPBsNTz6sZ6o75HwnGu0A==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.0.0-rc.1",
+        "@solana/codecs": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ES671CZUDLaXV46Vv3Kxd22coSQE4DlE7y0s9ChzQ7t4bLGv6DeHlHXU9kQBtou9koLR25wiDUWtvwNUyzUbHw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/promises": "2.0.0-rc.1",
+        "@solana/rpc": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0-rc.1.tgz",
+      "integrity": "sha512-pZTetOtRDwfuK/fyE8FKbtRsLQOTgEIQld3tskB85npUHaEgrnCYzp3nJtMhKOLel3w3f/27VtWLNSrRyyAiew==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-u9MH2Kk4P0E5rNxATdx/ljR2rp34S9VuC3Jzj9nCMKJ0XwvCD+ddTmIDop5Vs+96Ls9SGj0XaKAJtT+9S7SDpw==",
+      "peer": true,
+      "dependencies": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0-rc.1.tgz",
+      "integrity": "sha512-0fE40ZsJuqSOYOWbt8haHBIbhSfGckxJbwWEK+xRQaWr1sY1+MPUDnBawsLf818g9KRSNnS2Y3+/Sve7A3yfBA==",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.0.0-rc.1",
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/programs": "2.0.0-rc.1",
+        "@solana/rpc": "2.0.0-rc.1",
+        "@solana/rpc-parsed-types": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/signers": "2.0.0-rc.1",
+        "@solana/sysvars": "2.0.0-rc.1",
+        "@solana/transaction-confirmation": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
     },
     "node_modules/@stablelib/aead": {
       "version": "1.0.1",
@@ -6687,7 +7243,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -6817,14 +7372,12 @@
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "license": "MIT"
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -8513,7 +9066,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-      "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -8922,9 +9474,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -10112,7 +10664,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10542,14 +11093,12 @@
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "license": "MIT"
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-      "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
@@ -11476,6 +12025,12 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -12105,7 +12660,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -12707,7 +13261,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -12732,7 +13285,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.2.tgz",
       "integrity": "sha512-5nzMWDHy6f+koZOuYsArh2AXs73NfWYVlFyJJuCedr93GpY+Ku8qq10ropSXVfHK+H0T6paA88ww+/dV+1fBNA==",
-      "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -12757,20 +13309,17 @@
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12779,7 +13328,6 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -13158,8 +13706,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -13188,14 +13735,12 @@
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "engines": [
         "node >= 0.2.0"
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -16259,10 +16804,9 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.2.tgz",
-      "integrity": "sha512-YzggvfItxMY3Lwuax5rC18inhbjJv9Py7JXRHxTIi94JOLrqBsSsUUc5bbl5W6c11tXhdfpDPK0KzBhoGe8jjw==",
-      "license": "LGPL-3.0-only",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.4.tgz",
+      "integrity": "sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/uuid": "^8.3.4",
@@ -16285,7 +16829,6 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
       "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -16294,7 +16837,6 @@
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
       "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -16302,14 +16844,12 @@
     "node_modules/rpc-websockets/node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/rpc-websockets/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -16318,7 +16858,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17323,7 +17862,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
       "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -17553,8 +18091,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -17836,6 +18373,12 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "peer": true
     },
     "node_modules/unenv": {
       "version": "1.10.0",
@@ -20067,6 +20610,28 @@
         "util": "^0.12.4"
       },
       "dependencies": {
+        "@solana/web3.js": {
+          "version": "1.95.3",
+          "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.3.tgz",
+          "integrity": "sha512-O6rPUN0w2fkNqx/Z3QJMB9L225Ex10PRDH8bTaIUPZXMPV0QP8ZpPvjQnXK+upUczlRgzHzd6SjKIha1p+I6og==",
+          "requires": {
+            "@babel/runtime": "^7.25.0",
+            "@noble/curves": "^1.4.2",
+            "@noble/hashes": "^1.4.0",
+            "@solana/buffer-layout": "^4.0.1",
+            "agentkeepalive": "^4.5.0",
+            "bigint-buffer": "^1.1.5",
+            "bn.js": "^5.2.1",
+            "borsh": "^0.7.0",
+            "bs58": "^4.0.1",
+            "buffer": "6.0.3",
+            "fast-stable-stringify": "^1.0.0",
+            "jayson": "^4.1.1",
+            "node-fetch": "^2.7.0",
+            "rpc-websockets": "^9.0.2",
+            "superstruct": "^2.0.2"
+          }
+        },
         "bn.js": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -22600,6 +23165,45 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
+    "@solana-program/token": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.3.1.tgz",
+      "integrity": "sha512-EPPYjNnw7M7jiXSog3CVYdrFYiji5n3VxbgK9T9y6zpNSlvHvaSrWPdZU+Q0pLCi73EQyvk7oF3jsa/0Lb4ckg==",
+      "requires": {}
+    },
+    "@solana/accounts": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0-rc.1.tgz",
+      "integrity": "sha512-au6grz6iIgepKIbN2HUHKatFhg7mvIvdjFMDYpuEx+AGwK7vHnN5PsJqSCGQydthC2nVQwSZC9IgA5MF5wUHdw==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/addresses": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0-rc.1.tgz",
+      "integrity": "sha512-g31KrLZdECjAKceShlGoYxnWDmEVklpjPs8xOtnj/HWupEk+Mds4vtmTACTAeJkWZW/3x+z0aexMtO86MKA47g==",
+      "requires": {
+        "@solana/assertions": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/assertions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-dvxYCUB7ftZa5lWcsyMYLsGm204H6yVN8Q3ngluMG0rhTtScMBRklVg7Vs39ISwJOkJWJPGToaZ7DjNJ83bm1Q==",
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
     "@solana/buffer-layout": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
@@ -22608,33 +23212,402 @@
         "buffer": "~6.0.3"
       }
     },
-    "@solana/web3.js": {
-      "version": "1.95.3",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.3.tgz",
-      "integrity": "sha512-O6rPUN0w2fkNqx/Z3QJMB9L225Ex10PRDH8bTaIUPZXMPV0QP8ZpPvjQnXK+upUczlRgzHzd6SjKIha1p+I6og==",
+    "@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "peer": true,
       "requires": {
-        "@babel/runtime": "^7.25.0",
-        "@noble/curves": "^1.4.2",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.1",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^2.0.2"
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      }
+    },
+    "@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "peer": true,
+      "requires": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "requires": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "requires": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "requires": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        },
+        "commander": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
         }
+      }
+    },
+    "@solana/fast-stable-stringify": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0-rc.1.tgz",
+      "integrity": "sha512-TN8JY+Sbh5NNq4TqdWil8hXKx2d84bTHvY6jfBXNjM29S0fwpUpVRHUzOkuK1mjjWFNkMpfgJfozC0TjdUbkvA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@solana/functional": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0-rc.1.tgz",
+      "integrity": "sha512-BmedS5o8HTlU8/NA22I6urJqat9QYIw0oH6rKdMMBisDwX7MtgJhe38W8iLP7QCcxoJeS4526qaD8uD62+Pheg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@solana/instructions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-zkfL4WBHPbkMrYsuGZc/sekPa/oALIVvVGUw/gwAervMeLZ34cWCUE6WC2uUUh+bq3OFq0/FSFhAg2YbHHDyUw==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/keys": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ls3B0KOvfdiBH3/fnEjHhicfXsLLb4zApJlSX4X8NZ+2TmTJ2Jqa+MakgAzrsxL1FJkTJ1RDboR9xx2CHQtKzw==",
+      "peer": true,
+      "requires": {
+        "@solana/assertions": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "peer": true,
+      "requires": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/programs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-wF49DychwSz3sVmTF51R6DTHBGMP7Uhe7EdmCNu+Ef9EgKBJZFfrViOD6M8Q0b3WH//TV63HNlX/2QmHtJjQHg==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/promises": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0-rc.1.tgz",
+      "integrity": "sha512-iIaC52Ka+omGabGn2LHOSgEm9N2gI7Iyik6LE3DDxZ4MuYmGcJ4E315XuE/UVXWnc9qOfOjgtSaaOYhde0vyrQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@solana/rpc": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0-rc.1.tgz",
+      "integrity": "sha512-upqR/Ae5syzQDZkffTdU/09k1Vx073Gt4xkkpcWaTBmW0obVhrlvJvH2k5jrOQ13BZd2NVg1MWMEOBcy3+nJjQ==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/fast-stable-stringify": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/rpc-api": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-transport-http": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-api": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0-rc.1.tgz",
+      "integrity": "sha512-pg/w+0pgj3msBCC/hkZa9/qZHRdqh7MLsHMJInXnenO+Rzj6IyE47Ig6rt6GuI4OxYy+1d714jcPXVMA8p2YWw==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-parsed-types": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-parsed-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-5/AYNiZvR9do56VJgmTscRwnd9myt6x9uG7b0S3V+K5e0xzA9yJF68SzI4TQSNmLfWXCaVC90xGCWWkM19lLIQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@solana/rpc-spec": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0-rc.1.tgz",
+      "integrity": "sha512-E81IoNzLbp24T633klEqlRujd2i/rd8xVkJGt04DL/LGS4/cCWJEhkmOnfljxWafCPUundRXlPtNG3ZmHzEYqA==",
+      "peer": true,
+      "requires": {
+        "@solana/rpc-spec-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-spec-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-Z0gOrzasTYU+kNNnDDG2snZxBoBPMN8oFc0EE9HiDKN9JEsc+asexzKeq+Nea7JVqVFcN5V3bjqrpD86V5EOiQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@solana/rpc-subscriptions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-gHrVNWEbMi8uDO8BzpJkuDiHMcfD4SrfLRohROnHx0SfSlEGxvIkBjPnwOYIoS7IkWk95e19s7hJoBNn2TX4kw==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/fast-stable-stringify": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/promises": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-api": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-transport-websocket": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      },
+      "dependencies": {
+        "@solana/rpc-subscriptions-transport-websocket": {
+          "version": "2.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-transport-websocket/-/rpc-subscriptions-transport-websocket-2.0.0-rc.1.tgz",
+          "integrity": "sha512-NxheQmG6Ku9gjF3TyGbM8Nxx6fOU3m89LdfH9SQNu6yME6VXKWuT1LaY24T707yDOoKZJsOWabRrQtNfJ+3HZA==",
+          "peer": true,
+          "requires": {
+            "@solana/errors": "2.0.0-rc.1",
+            "@solana/rpc-subscriptions-spec": "2.0.0-rc.1"
+          }
+        },
+        "ws": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+          "peer": true,
+          "requires": {}
+        }
+      }
+    },
+    "@solana/rpc-subscriptions-api": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0-rc.1.tgz",
+      "integrity": "sha512-HmuJmB+RnpYzpiwDWncYFey0lrdFt8KbFvH0JvxEB7NX6V9NgGQIwRY1bfoaeSwX6t93p4nBWr2ckJWLNjXzCw==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-transformers": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-subscriptions-spec": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0-rc.1.tgz",
+      "integrity": "sha512-eXRVlMr9zw4JlBoJgVhFRxFs3Iaowhtt35ZIMD+OoTqgKniL62iGiZ3hXsuMDToMvQCBd0UfI+ZVdF2gLQdg9A==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-transformers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-YM25X4Eeh39UR2AoSrCFn74W99bQk0/DLqyPgZpNBRbszzEifGHqu83NNFwBuPMVc9q7ilf5s6r6pqhWP+5JJw==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/rpc-transport-http": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0-rc.1.tgz",
+      "integrity": "sha512-Byvn2LnaCgTnEyr78wcgh8SrVHo+L6/l1kXQW05cNAjjbS8d8z4meBUBrXDWHmCsWy7RdnrTcBixPPtE+pUebw==",
+      "peer": true,
+      "requires": {
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-spec": "2.0.0-rc.1",
+        "undici-types": "^6.19.5"
+      }
+    },
+    "@solana/rpc-types": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0-rc.1.tgz",
+      "integrity": "sha512-EcGx9VXqA0+uYEdaa1lKTaGBVxLyNL8nkecE4GkqQ+ntRyYlNBPecd4b8siQGSleUQa+Tk/VSPUawSkHqNTLug==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      }
+    },
+    "@solana/signers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-dv3oKSF+AIaHKpnSkmzEf+jXVcA3nl015+Mp/WQZYzQJS01dlrmnd4N5DOSn2CaPRJ0TLujHkupxkOFXbe149A==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      }
+    },
+    "@solana/sysvars": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0-rc.1.tgz",
+      "integrity": "sha512-nLiuisgbRw7FkJrxPJOBzf0ro7ZCk0gWgMyLQexe9oPoTzdZnWbHI4ldYDmtfdy2dkPBsNTz6sZ6o75HwnGu0A==",
+      "peer": true,
+      "requires": {
+        "@solana/accounts": "2.0.0-rc.1",
+        "@solana/codecs": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/transaction-confirmation": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ES671CZUDLaXV46Vv3Kxd22coSQE4DlE7y0s9ChzQ7t4bLGv6DeHlHXU9kQBtou9koLR25wiDUWtvwNUyzUbHw==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/promises": "2.0.0-rc.1",
+        "@solana/rpc": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
+      }
+    },
+    "@solana/transaction-messages": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0-rc.1.tgz",
+      "integrity": "sha512-pZTetOtRDwfuK/fyE8FKbtRsLQOTgEIQld3tskB85npUHaEgrnCYzp3nJtMhKOLel3w3f/27VtWLNSrRyyAiew==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1"
+      }
+    },
+    "@solana/transactions": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0-rc.1.tgz",
+      "integrity": "sha512-u9MH2Kk4P0E5rNxATdx/ljR2rp34S9VuC3Jzj9nCMKJ0XwvCD+ddTmIDop5Vs+96Ls9SGj0XaKAJtT+9S7SDpw==",
+      "peer": true,
+      "requires": {
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1"
+      }
+    },
+    "@solana/web3.js": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0-rc.1.tgz",
+      "integrity": "sha512-0fE40ZsJuqSOYOWbt8haHBIbhSfGckxJbwWEK+xRQaWr1sY1+MPUDnBawsLf818g9KRSNnS2Y3+/Sve7A3yfBA==",
+      "peer": true,
+      "requires": {
+        "@solana/accounts": "2.0.0-rc.1",
+        "@solana/addresses": "2.0.0-rc.1",
+        "@solana/codecs": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1",
+        "@solana/functional": "2.0.0-rc.1",
+        "@solana/instructions": "2.0.0-rc.1",
+        "@solana/keys": "2.0.0-rc.1",
+        "@solana/programs": "2.0.0-rc.1",
+        "@solana/rpc": "2.0.0-rc.1",
+        "@solana/rpc-parsed-types": "2.0.0-rc.1",
+        "@solana/rpc-subscriptions": "2.0.0-rc.1",
+        "@solana/rpc-types": "2.0.0-rc.1",
+        "@solana/signers": "2.0.0-rc.1",
+        "@solana/sysvars": "2.0.0-rc.1",
+        "@solana/transaction-confirmation": "2.0.0-rc.1",
+        "@solana/transaction-messages": "2.0.0-rc.1",
+        "@solana/transactions": "2.0.0-rc.1"
       }
     },
     "@stablelib/aead": {
@@ -24530,9 +25503,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -26359,6 +27332,12 @@
       "requires": {
         "strnum": "^1.0.5"
       }
+    },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "peer": true
     },
     "fastq": {
       "version": "1.15.0",
@@ -29721,9 +30700,9 @@
       }
     },
     "rpc-websockets": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.2.tgz",
-      "integrity": "sha512-YzggvfItxMY3Lwuax5rC18inhbjJv9Py7JXRHxTIi94JOLrqBsSsUUc5bbl5W6c11tXhdfpDPK0KzBhoGe8jjw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.4.tgz",
+      "integrity": "sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==",
       "requires": {
         "@swc/helpers": "^0.5.11",
         "@types/uuid": "^8.3.4",
@@ -30862,6 +31841,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "peer": true
     },
     "unenv": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@solana-program/token": "^0.3.1",
+    "@solana/addresses": "^2.0.0-rc.1",
     "@tanstack/react-query": "^4.29.19",
     "@types/node": "20.4.1",
     "@types/react": "18.2.14",


### PR DESCRIPTION
When the treasury account is off-curve (as it is here, because it's a Squads multisig) certain wallets will reject this payment request. As of this writing those include Backpack (cc/ @ph101pp) and Solflare (cc/ @vidorge). To hack around this, we derive the address of the associated token account and use it as the recipient, even though this is a violation of the [Solana Pay specification](https://docs.solanapay.com/spec#recipient).